### PR TITLE
Clarify install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ To install the extension, execute:
 ```bash
 pip install jupyterlab jupyterlab-search-replace
 ```
+Note: You still need `ripgrep` installed for `jupyterlab-search-replace` to work.
 
 or
 


### PR DESCRIPTION
The instructions for pip install does not install a working version of `jupyterlab-search-replace` because we need `ripgrep` installed. It does not seem like `ripgrep` can be installed with pip: https://pypi.org/search/?q=ripgrep like it can with conda: https://anaconda.org/conda-forge/ripgrep