### PR TITLE
fix: only detect missing matches via matches entry

### DIFF
--- a/jupyterlab_search_replace/search_engine.py
+++ b/jupyterlab_search_replace/search_engine.py
@@ -235,12 +235,7 @@ class SearchEngine:
                 output = json.loads(output)
                 if output["type"] == "summary":
                     stats = output["data"]["stats"]
-                    if (
-                        stats["matched_lines"] == 0
-                        and stats["matches"] == 0
-                        and stats["searches"] == 0
-                        and stats["searches_with_match"] == 0
-                    ):
+                    if stats["matches"] == 0:
                         return {"matches": []}
             except (json.JSONDecodeError, KeyError):
                 # If parsing the JSON fails or one key is missing


### PR DESCRIPTION
The summary printer in `ripgrep` was recently fixed. As such, our test suite is too strict on ripgrep `<15` semantics: https://github.com/BurntSushi/ripgrep/discussions/3178

This causes our test suite to fail on `rg>=15` because we have some logic that massages an exit code of 1 (with no matches in the summary statistics) into an HTTP 200 no-matches response. This PR loosens the test to only check `matches` in this case.