### PR TITLE
fix: pin @microsoft/fast-foundation to 2.49.4 to avoid infinite recursion at startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,9 @@
         "watch:src": "tsc -w --sourceMap"
     },
     "packageManager": "yarn@3.5.0",
+    "resolutions": {
+        "@microsoft/fast-foundation": "2.49.4"
+    },
     "dependencies": {
         "@codemirror/state": "^6.2.1",
         "@jupyter-notebook/tree": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1402,22 +1402,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@microsoft/fast-element@npm:^1.14.0":
-  version: 1.14.0
-  resolution: "@microsoft/fast-element@npm:1.14.0"
-  checksum: 58765739492997a5c51f7841cf6f334e2d2c4ad2365db4a228c07df1c89d139b026abf6afc6691ac48066070d3c94d09afdea2929bdca25842f778293e19892d
-  languageName: node
-  linkType: hard
-
-"@microsoft/fast-foundation@npm:^2.49.4":
-  version: 2.50.0
-  resolution: "@microsoft/fast-foundation@npm:2.50.0"
+"@microsoft/fast-foundation@npm:2.49.4":
+  version: 2.49.4
+  resolution: "@microsoft/fast-foundation@npm:2.49.4"
   dependencies:
-    "@microsoft/fast-element": ^1.14.0
+    "@microsoft/fast-element": ^1.12.0
     "@microsoft/fast-web-utilities": ^5.4.1
     tabbable: ^5.2.0
     tslib: ^1.13.0
-  checksum: 651501eb8cd5a3e583638f70a4e7c0ad30952fe12adedd5c4c24861515d0aaeec0e83d1f1cd25dece899d2fa1614b415001c461f76bb84b20e1a8e18a3fcf219
+  checksum: e979cd500aaba28090e8d9cdc6192933db01803c13288c11aded89aa54da6f0a70256ff2f249754b1c95d9abad369a18401e1df98d672e2823b83cf4cd88ad55
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes #144

Versions 1.1.1 and 1.1.2 cause JupyterLab to freeze at startup with `RangeError: Maximum call stack size exceeded` / `InternalError: too much recursion` errors in the browser console. This PR fixes the root cause.

## Root cause

The bump from `@jupyter/react-components@^0.13.2` (in 1.1.0) to `^0.16.6` (in 1.1.1+) transitively pulled in **`@microsoft/fast-foundation 2.50.0`**, which introduced a regression in `Store.delete()`:

```js
// 2.49.x — safe
delete(token) {
    this.values.delete(token);
}

// 2.50.0 — triggers infinite recursion
delete(token) {
    this.values.delete(token);
    Observable.getNotifier(this).notify(token.id);  // ← new line
}
```

This new `notify()` call creates an infinite re-entrant cycle:

```
Store.delete()
  → notify() fires to all child DesignTokenNodes
    → handleChange() → hydrate()
      → bindingObservers.get(token) === undefined  ← not yet registered
        → setupBindingObserver() → new DesignTokenBindingObserver()
          → constructor calls handleChange() synchronously
            → store.set() → notify() → hydrate()
              → bindingObservers.get(token) still undefined
                → setupBindingObserver() → ∞
```

The cycle exists because `setupBindingObserver()` registers the observer **after** the constructor returns, but the constructor fires `handleChange()` synchronously — so any re-entrant call to `hydrate()` during construction finds no observer and recurses.

This bug is tracked upstream in [microsoft/fast#7057](https://github.com/microsoft/fast/issues/7057). A maintainer has confirmed that `@microsoft/fast-foundation` is **deprecated** and no patch will be issued — the team is migrating to `@microsoft/fast-element@2.0.0`.

## Fix

Add a `resolutions` entry to pin `@microsoft/fast-foundation` to `2.49.4` (the last safe version before the regression):

```json
"resolutions": {
    "@microsoft/fast-foundation": "2.49.4"
}
```

This is a standard Yarn 3 mechanism to override transitive dependency resolution. The `yarn.lock` has been regenerated accordingly.

## Testing

Confirmed that `yarn.lock` resolves `@microsoft/fast-foundation` to `2.49.4` only (no 2.50.0 entry present).